### PR TITLE
Update ibc-channels

### DIFF
--- a/relaying/ibc-channels
+++ b/relaying/ibc-channels
@@ -10,5 +10,7 @@
 
 | source chain-id  | source channel  | destination | destination chain-id  | destination channel |
 | ---------------- | --------------- | ----------- | --------------------- | ------------------- |
+| teritori-testnet-v2 | channel-0 | cosmos-testnet | theta-testnet-001 | channel-499 |
+| teritori-testnet-v2 | channel-1 | osmosis-testnet | osmo-test-4 | channel-353 |
 | teritori-testnet-v2 | channel-X | cosmos | cosmoshub-4 | channel-XXX |
 | teritori-testnet-v2 | channel-X | osmosis | osmosis-1 | channel-XXX |


### PR DESCRIPTION
Cros-Nest have created and maintain IBC link with cosmos and osmosis testnets since teritori-testnet-v1